### PR TITLE
import globally unique package names not relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "effe"]
 	path = effe
-	url = git@github.com:siscia/effe.git
+	url = https://github.com/dougnukem/effe.git

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,11 +1,11 @@
 package builder
 
 import (
-	"effe-tool/commons"
-	"effe-tool/sources"
 	"encoding/json"
 	"fmt"
 	"github.com/codegangsta/cli"
+	"github.com/siscia/effe-tool/commons"
+	"github.com/siscia/effe-tool/sources"
 	"hash/fnv"
 	"io"
 	"math/rand"

--- a/effe-tool.go
+++ b/effe-tool.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"effe-tool/builder"
-	"effe-tool/factory"
 	"github.com/codegangsta/cli"
+	"github.com/siscia/effe-tool/builder"
+	"github.com/siscia/effe-tool/factory"
 	"math/rand"
 	"os"
 	"time"

--- a/factory/factory.go
+++ b/factory/factory.go
@@ -1,10 +1,10 @@
 package factory
 
 import (
-	"effe-tool/commons"
-	"effe-tool/sources"
 	"fmt"
 	"github.com/codegangsta/cli"
+	"github.com/siscia/effe-tool/commons"
+	"github.com/siscia/effe-tool/sources"
 )
 
 func CreateNewEffe(c *cli.Context) {


### PR DESCRIPTION
Closes https://github.com/siscia/effe-tool/issues/1

Made the package import globally unique so that the package is "go-gettable" as described here:
- http://blog.golang.org/organizing-go-code

> Sometimes people set GOPATH to the root of their source repository and put their packages in directories relative to the repository root, such as "src/my/package". On one hand, this keeps the import paths short ("my/package" instead of "github.com/me/project/my/package"), but on the other it breaks go get and forces users to re-set their GOPATH to use the package. Don't do this.
## Note

This references https://github.com/siscia/effe/pull/2 and changed the submodules to reference the forked `effe` repo, I can update this PR once that gets merged in to reference the `effe` repo. Until then this PR shouldn't be merged in.
